### PR TITLE
check in `package-lock.json` diff after running `npm i`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "fe-minicom",
+  "name": "frontend-minicom-public",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "fe-minicom",
+      "name": "frontend-minicom-public",
       "version": "0.0.0",
       "dependencies": {
         "react": "^19.1.0",


### PR DESCRIPTION
syncs mismatched `name` field across package.json and package-lock.json